### PR TITLE
fix: `Object has been destroyed` の抑止

### DIFF
--- a/electron/index.ts
+++ b/electron/index.ts
@@ -46,7 +46,7 @@ const backgroundUsecase = getBackgroundUsecase(getSettingStore('v0-settings'));
 
 const createOrGetMainWindow = async (): Promise<BrowserWindow> => {
   const mainWindow = electronUtil.createOrGetWindow();
-  electronUtil.setTray(mainWindow);
+  electronUtil.setTray();
   // 他のウィンドウ設定やイベントリスナーをここに追加
   return mainWindow;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- ウィンドウの作成と管理を扱う`createWindow`をリファクタリングしました。
	- メインウィンドウを追跡するための`mainWindow`変数を導入しました。
	- メインウィンドウを取得または作成する`getWindow`関数を追加しました。
	- イベントハンドラーを更新して、フォーカスされたウィンドウを使用するようにしました。
	- ウィンドウ管理のために`setTray`を`createOrGetWindow`を使用するように変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->